### PR TITLE
Fixed capitalization to remain consistent with original input

### DIFF
--- a/analyzeText.js
+++ b/analyzeText.js
@@ -31,7 +31,6 @@ registerKeywordListeners = (keyReplacements) => {
             let replace = keyReplacements[parseInt(this.id.replace("warningId", ""))];
             let innerText = this.textContent;
             this.innerHTML = processCapitalization(replace, innerText);
-            console.log(this.textContent);
             this.classList.remove("warning");
             this.removeAttribute("title");
         });
@@ -47,6 +46,7 @@ function prepareForDisplay(str){
 return removeBeginningBr(formatLineBreaks(str, "<br>", ["br"]));
 }
 
+//Preserves original first letter capitalization
 processCapitalization = (replace, innerText) => {
     if(innerText.charAt(0) === innerText.charAt(0).toUpperCase()) {
         replace = replace.charAt(0).toUpperCase() + replace.slice(1);


### PR DESCRIPTION
-Fixed this based on Koperski's feedback. Previously, when you had something like "Hey, Sam!" it would correct to "hello, sam". I reconstructed the replacements so that it preserves the first letter capitalization of a word. For example, "Hey, Sam" will now correct to "Hello, Sam", while "Why, hey there" will still replace to "Why, hello there".

If you guys feel it is okay we can include it in Moonshot, but otherwise this can go in the hackathon.