### PR TITLE
Made Analytics more descriptive

### DIFF
--- a/asyncTracking.js
+++ b/asyncTracking.js
@@ -15,5 +15,5 @@ _gaq.push(['_trackPageview']);
 })();
 
 function trackAcceptChange(e) {
-    _gaq.push(['_trackEvent', e.target.id, 'Accepted a Change']);
+    _gaq.push(['_trackEvent', e.target.id, e.target.textContent]);
 }


### PR DESCRIPTION
Google Analytics now shows what words people accepted instead of just displaying the warningId.